### PR TITLE
removed no_translations because it's deprecated in Django 2.2.8

### DIFF
--- a/django_minio_backend/management/commands/initialize_buckets.py
+++ b/django_minio_backend/management/commands/initialize_buckets.py
@@ -1,11 +1,10 @@
-from django.core.management.base import BaseCommand, no_translations
+from django.core.management.base import BaseCommand
 from django_minio_backend.models import MinioBackend
 
 
 class Command(BaseCommand):
     help = 'Helps initializing Minio buckets by creating them and setting their policies.'
 
-    @no_translations
     def handle(self, *args, **options):
         self.stdout.write(f"Initializing Minio buckets...")
         m = MinioBackend()


### PR DESCRIPTION
Django 2.2.8 removed no_translations decorator, hence initialize_buckets commands is failing....
If you have another idea let me know, but removing this command solves the issue