### PR TITLE
Fixes ssl error when using non ssl/direct/internal connection

### DIFF
--- a/django_minio_backend/models.py
+++ b/django_minio_backend/models.py
@@ -232,7 +232,10 @@ class MinioBackend(Storage):
             mss.add_message('MINIO_ENDPOINT is not configured in Django settings')
             return mss
 
-        c = urllib3.HTTPSConnectionPool(self.__MINIO_ENDPOINT, cert_reqs='CERT_NONE', assert_hostname=False)
+        if self.__MINIO_USE_HTTPS:
+            c = urllib3.HTTPSConnectionPool(self.__MINIO_ENDPOINT, cert_reqs='CERT_NONE', assert_hostname=False)
+        else:
+            c = urllib3.HTTPConnectionPool(self.__MINIO_ENDPOINT)
         try:
             r = c.request('GET', '/minio/index.html')
             return MinioServerStatus(r)


### PR DESCRIPTION
Im running my own minio server in kubernetes, I connect internally without ssl so I access it without ssl on an internal dns name causing the ssl check to fail with:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/code.py", line 90, in runcode
    exec(code, self.locals)
  File "<console>", line 1, in <module>
  File "/usr/local/lib/python3.7/site-packages/urllib3/request.py", line 76, in request
    method, url, fields=fields, headers=headers, **urlopen_kw
  File "/usr/local/lib/python3.7/site-packages/urllib3/request.py", line 97, in request_encode_url
    return self.urlopen(method, url, **extra_kw)
  File "/usr/local/lib/python3.7/site-packages/urllib3/connectionpool.py", line 767, in urlopen
    **response_kw
  File "/usr/local/lib/python3.7/site-packages/urllib3/connectionpool.py", line 767, in urlopen
    **response_kw
  File "/usr/local/lib/python3.7/site-packages/urllib3/connectionpool.py", line 767, in urlopen
    **response_kw
  File "/usr/local/lib/python3.7/site-packages/urllib3/connectionpool.py", line 727, in urlopen
    method, url, error=e, _pool=self, _stacktrace=sys.exc_info()[2]
  File "/usr/local/lib/python3.7/site-packages/urllib3/util/retry.py", line 446, in increment
    raise MaxRetryError(_pool, url, error or ResponseError(cause))
urllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='fpo-api-minio:9000', port=None): Max retries exceeded with url: /minio/index.html (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1091)')))
```