### PR TITLE
Returning content bytes on MinioBackend._save

### DIFF
--- a/django_minio_backend/models.py
+++ b/django_minio_backend/models.py
@@ -144,11 +144,14 @@ class MinioBackend(Storage):
 
         # Upload object
         file_path: Path = Path(file_path_name)  # app name + file.suffix
+        content_bytes: io.BytesIO = io.BytesIO(content.read())
+        content_length: int = len(content_bytes.getvalue())
+
         self.client.put_object(
             bucket_name=self.bucket,
             object_name=file_path.as_posix(),
-            data=content,
-            length=content.size,
+            data=content_bytes,
+            length=content_length,
             content_type=self._guess_content_type(file_path_name, content),
             metadata=self._META_KWARGS.get('metadata', None),
             sse=self._META_KWARGS.get('sse', None),


### PR DESCRIPTION
# Info
I was facing an issue were the content length was not matching the content size, because the content was being interpreted as empty:
```
OSError at /my-fancy-endpoint
stream having not enough data;expected: 666, got: 0 bytes
```

- Issue occurs if I upload files as iso, text, pdf and so forth.
- Minio SDK Version: 7.1.0

This MR is also related to the closed issue #21.
