### PR TITLE
Fixed validate settings

### DIFF
--- a/django_minio_backend/models.py
+++ b/django_minio_backend/models.py
@@ -419,7 +419,7 @@ class MinioBackend(Storage):
         """
         validate_settings raises a ConfigurationError exception when one of the following conditions is met:
           * Neither MINIO_PRIVATE_BUCKETS nor MINIO_PUBLIC_BUCKETS have been declared and configured with at least 1 bucket
-          * A mandatory parameter (ENDPOINT, ACCESS_KEY, SECRET_KEY or USE_HTTP) hasn't been declared and configured properly
+          * A mandatory parameter (ENDPOINT, ACCESS_KEY or SECRET_KEY) hasn't been declared and configured properly
         """
         # minimum 1 bucket has to be declared
         if not (get_setting("MINIO_PRIVATE_BUCKETS") or get_setting("MINIO_PUBLIC_BUCKETS")):

--- a/django_minio_backend/models.py
+++ b/django_minio_backend/models.py
@@ -89,7 +89,7 @@ class MinioBackend(Storage):
         self.__MINIO_EXTERNAL_ENDPOINT: str = get_setting("MINIO_EXTERNAL_ENDPOINT", self.__MINIO_ENDPOINT)
         self.__MINIO_ACCESS_KEY: str = get_setting("MINIO_ACCESS_KEY")
         self.__MINIO_SECRET_KEY: str = get_setting("MINIO_SECRET_KEY")
-        self.__MINIO_USE_HTTPS: bool = get_setting("MINIO_USE_HTTPS")
+        self.__MINIO_USE_HTTPS: bool = get_setting("MINIO_USE_HTTPS", False)
         self.__MINIO_EXTERNAL_ENDPOINT_USE_HTTPS: bool = get_setting("MINIO_EXTERNAL_ENDPOINT_USE_HTTPS", self.__MINIO_USE_HTTPS)
         self.__MINIO_BUCKET_CHECK_ON_SAVE: bool = get_setting("MINIO_BUCKET_CHECK_ON_SAVE", False)
 
@@ -431,10 +431,10 @@ class MinioBackend(Storage):
                 'must be configured in your settings.py (can be both)'
             )
         # mandatory parameters must be configured
-        mandatory_parameters = (self.__MINIO_ENDPOINT, self.__MINIO_ACCESS_KEY, self.__MINIO_SECRET_KEY, self.__MINIO_USE_HTTPS)
+        mandatory_parameters = (self.__MINIO_ENDPOINT, self.__MINIO_ACCESS_KEY, self.__MINIO_SECRET_KEY)
         if any([bool(x) is False for x in mandatory_parameters]):
             raise ConfigurationError(
-                "A mandatory parameter (ENDPOINT, ACCESS_KEY, SECRET_KEY or USE_HTTP) hasn't been configured properly"
+                "A mandatory parameter (ENDPOINT, ACCESS_KEY, or SECRET_KEY) hasn't been configured properly"
             )
 
 


### PR DESCRIPTION
I had the `MINIO_USE_HTTPS=False` in my settings and the library failed to start as `validate_settings` requires `USE_HTTPS` as `True` which should not be enforced on the user.

I have removed it from mandatory settings and set it's default value as `False`