### PR TITLE
Make django-mini-backend Region aware

### DIFF
--- a/DjangoExampleProject/settings.py
+++ b/DjangoExampleProject/settings.py
@@ -154,6 +154,7 @@ MINIO_EXTERNAL_ENDPOINT_USE_HTTPS = bool(distutils.util.strtobool(os.getenv("GH_
 MINIO_ACCESS_KEY = os.getenv("GH_MINIO_ACCESS_KEY", "Q3AM3UQ867SPQQA43P2F")
 MINIO_SECRET_KEY = os.getenv("GH_MINIO_SECRET_KEY", "zuf+tfteSlswRu7BJ86wekitnifILbZam1KYY3TG")
 MINIO_USE_HTTPS = bool(distutils.util.strtobool(os.getenv("GH_MINIO_USE_HTTPS", "true")))
+MINIO_REGION = os.getenv("GH_MINIO_REGION", "us-east-1")
 MINIO_PRIVATE_BUCKETS = [
     'django-backend-dev-private',
     'my-media-files-bucket',

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ from typing import List, Tuple
 MINIO_ENDPOINT = 'minio.your-company.co.uk'
 MINIO_EXTERNAL_ENDPOINT = "external-minio.your-company.co.uk"  # Default is same as MINIO_ENDPOINT
 MINIO_EXTERNAL_ENDPOINT_USE_HTTPS = True  # Default is same as MINIO_USE_HTTPS
+MINIO_REGION = 'us-east-1'  # Default is set to None
 MINIO_ACCESS_KEY = 'yourMinioAccessKey'
 MINIO_SECRET_KEY = 'yourVeryS3cr3tP4ssw0rd'
 MINIO_USE_HTTPS = True

--- a/django_minio_backend/models.py
+++ b/django_minio_backend/models.py
@@ -93,6 +93,7 @@ class MinioBackend(Storage):
         self.__MINIO_ACCESS_KEY: str = get_setting("MINIO_ACCESS_KEY")
         self.__MINIO_SECRET_KEY: str = get_setting("MINIO_SECRET_KEY")
         self.__MINIO_USE_HTTPS: bool = get_setting("MINIO_USE_HTTPS")
+        self.__MINIO_REGION: str = get_setting("MINIO_REGION", None)
         self.__MINIO_EXTERNAL_ENDPOINT_USE_HTTPS: bool = get_setting("MINIO_EXTERNAL_ENDPOINT_USE_HTTPS", self.__MINIO_USE_HTTPS)
         self.__MINIO_BUCKET_CHECK_ON_SAVE: bool = get_setting("MINIO_BUCKET_CHECK_ON_SAVE", False)
 
@@ -373,7 +374,7 @@ class MinioBackend(Storage):
             secret_key=self.__MINIO_SECRET_KEY,
             secure=self.__MINIO_EXTERNAL_ENDPOINT_USE_HTTPS if fake else self.__MINIO_USE_HTTPS,
             http_client=self.HTTP_CLIENT,
-            region='us-east-1' if fake else None,
+            region=self.__MINIO_REGION,
         )
         if fake:
             self.__CLIENT_FAKE = mc

--- a/django_minio_backend/models.py
+++ b/django_minio_backend/models.py
@@ -93,7 +93,7 @@ class MinioBackend(Storage):
         self.__MINIO_ACCESS_KEY: str = get_setting("MINIO_ACCESS_KEY")
         self.__MINIO_SECRET_KEY: str = get_setting("MINIO_SECRET_KEY")
         self.__MINIO_USE_HTTPS: bool = get_setting("MINIO_USE_HTTPS")
-        self.__MINIO_REGION: str = get_setting("MINIO_REGION", None)
+        self.__MINIO_REGION: str = get_setting("MINIO_REGION", "us-east-1") # MINIO defaults to "us-east-1" when region is set to None
         self.__MINIO_EXTERNAL_ENDPOINT_USE_HTTPS: bool = get_setting("MINIO_EXTERNAL_ENDPOINT_USE_HTTPS", self.__MINIO_USE_HTTPS)
         self.__MINIO_BUCKET_CHECK_ON_SAVE: bool = get_setting("MINIO_BUCKET_CHECK_ON_SAVE", False)
 
@@ -249,7 +249,8 @@ class MinioBackend(Storage):
         :return: (str) URL to object
         """
         if self.is_bucket_public:
-            return f'{self.base_url_external}/{self.bucket}/{name}'
+            base_url = self.client._base_url.build("GET", self.__MINIO_REGION).geturl()
+            return f'{base_url}{self.bucket}/{name}'
         if self.same_endpoints:
             # in this scenario the fake client is not needed
             client = self.client


### PR DESCRIPTION
Similar PR was raised at https://github.com/theriverman/django-minio-backend/pull/38 but unfortunately it was not a complete implementation. 

The following were changed and added:

- Get `MINIO_REGION` value from settings or set it to `us-east-1` which is the default value (Minio itself uses that as a default value)
- If the bucket is public, generate the base URL from the instantiated Minio Client and not hardcode the base URL
- Django Example App and `README.md` is updated

This Fixes few problems:
- Hosted minio solutions are now Region aware, this PR makes it compatible
- Works with Amazon S3 services with all their latest security changes which they have implemented.

I have already tested it out with local/hosted instance of minio and with AWS S3 service. Forked version of this is published in my PyPI: https://pypi.org/project/ak-django-minio-backend/ (I'll delete as soon as this gets merged, tested, approved released)