### PR TITLE
[fix] pin minio version to 7.2.7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Django>=3.2
-minio>=7.0.2
+minio==7.2.7
 Pillow
 setuptools


### PR DESCRIPTION
## Problem
File save fails when the `minio` package version is equal to **7.2.8**.
Possible cause of failure might be django-minio-backend does not supporting the newer version of `minio`.
Error that was raised is:
```python
TypeError: a bytes-like object is required, not 'str'
```
File save works fine with version 7.2.7 of the minio package

## Applied solution
Resolved the problem by pinning the Minio package version to **7.2.7**.