### PR TITLE
Resolves Error: a bytes-like object is required, not 'str'

### DIFF
--- a/django_minio_backend/models.py
+++ b/django_minio_backend/models.py
@@ -271,7 +271,7 @@ class MinioBackend(Storage):
         try:
             u: str = client.presigned_get_object(
                 bucket_name=self.bucket,
-                object_name=name.encode('utf-8'),
+                object_name=name,
                 expires=get_setting("MINIO_URL_EXPIRY_HOURS", timedelta(days=7))  # Default is 7 days
             )
             return u


### PR DESCRIPTION
Compatiblity with minio-py version 7.2.8